### PR TITLE
Add environments

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -609,7 +609,12 @@ impl Mold {
         // it's done here so that parent group's configuration can override one
         // of the subrecipes in the group
         if let Some(vars) = &mut task.vars {
-          vars.extend(recipe.env_vars(&self.envs).iter().map(|(k, v)| (k.clone(), v.clone())));
+          vars.extend(
+            recipe
+              .env_vars(&self.envs)
+              .iter()
+              .map(|(k, v)| (k.clone(), v.clone())),
+          );
         }
       }
 
@@ -621,7 +626,12 @@ impl Mold {
 
     // extend the variables with the recipe's variables
     let mut vars = prev_vars.clone();
-    vars.extend(recipe.env_vars(&self.envs).iter().map(|(k, v)| (k.clone(), v.clone())));
+    vars.extend(
+      recipe
+        .env_vars(&self.envs)
+        .iter()
+        .map(|(k, v)| (k.clone(), v.clone())),
+    );
 
     // extend the variables with the recipe's environment variables
     for env_name in &self.envs {
@@ -881,7 +891,7 @@ impl Recipe {
   }
 
   /// Return this recipe's variables with activated environments
-  pub fn env_vars(&self, envs: &Vec<String>) -> VarMap {
+  pub fn env_vars(&self, envs: &[String]) -> VarMap {
     let mut vars = self.vars().clone();
     for env_name in envs {
       if let Some(env) = self.get_env(env_name) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ pub struct Mold {
   script_dir: PathBuf,
 
   /// which environments to use in the environment
-  env: Option<String>,
+  envs: Vec<String>,
 
   /// the parsed moldfile data
   data: Moldfile,
@@ -285,7 +285,7 @@ impl Mold {
       dir: fs::canonicalize(dir)?,
       clone_dir: fs::canonicalize(clone_dir)?,
       script_dir: fs::canonicalize(script_dir)?,
-      env: None,
+      envs: vec![],
       data,
     })
   }
@@ -361,7 +361,10 @@ impl Mold {
   }
 
   pub fn set_env(&mut self, env: Option<String>) {
-    self.env = env;
+    self.envs = match env {
+      Some(envs) => envs.split(',').map(|x| x.into()).collect(),
+      None => vec![],
+    };
   }
 
   /// Find a Recipe by name
@@ -721,7 +724,7 @@ impl Mold {
   pub fn adopt(mut self, parent: &Self) -> Self {
     self.clone_dir = parent.clone_dir.clone();
     self.script_dir = parent.script_dir.clone();
-    self.env = parent.env.clone();
+    self.envs = parent.envs.clone();
     self
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -612,6 +612,13 @@ impl Mold {
     let mut vars = prev_vars.clone();
     vars.extend(recipe.vars().iter().map(|(k, v)| (k.clone(), v.clone())));
 
+    // extend the variables with the recipe's environment variables
+    for env_name in &self.envs {
+      if let Some(env) = recipe.get_env(env_name) {
+        vars.extend(env.iter().map(|(k, v)| (k.clone(), v.clone())));
+      }
+    }
+
     let task = match recipe {
       Recipe::Command(target) => Some(Task::from_args(&target.command, Some(&vars))),
       Recipe::File(target) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ pub struct Mold {
   dir: PathBuf,
   clone_dir: PathBuf,
   script_dir: PathBuf,
+  env: Option<String>,
   data: Moldfile,
 }
 
@@ -256,6 +257,7 @@ impl Mold {
       dir: fs::canonicalize(dir)?,
       clone_dir: fs::canonicalize(clone_dir)?,
       script_dir: fs::canonicalize(script_dir)?,
+      env: None,
       data,
     })
   }
@@ -324,6 +326,10 @@ impl Mold {
 
   pub fn env(&self) -> &EnvMap {
     &self.data.environment
+  }
+
+  pub fn set_env(&mut self, env: Option<String>) {
+    self.env = env;
   }
 
   /// Find a Recipe by name
@@ -683,6 +689,7 @@ impl Mold {
   pub fn adopt(mut self, parent: &Self) -> Self {
     self.clone_dir = parent.clone_dir.clone();
     self.script_dir = parent.script_dir.clone();
+    self.env = parent.env.clone();
     self
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ pub mod remote;
 pub type RecipeMap = BTreeMap<String, Recipe>;
 pub type IncludeVec = Vec<Include>;
 pub type TypeMap = BTreeMap<String, Type>;
-pub type EnvMap = BTreeMap<String, String>;
+pub type VarMap = BTreeMap<String, String>;
 pub type TaskSet = indexmap::IndexSet<String>;
 
 #[derive(Debug)]
@@ -58,8 +58,10 @@ pub struct Moldfile {
   pub types: TypeMap,
 
   /// A list of environment variables used to parametrize recipes
+  ///
+  /// BREAKING: Renamed from `environment` in 0.3.0
   #[serde(default)]
-  pub environment: EnvMap,
+  pub variables: VarMap,
 }
 
 fn default_recipe_dir() -> PathBuf {
@@ -100,8 +102,10 @@ pub struct RecipeBase {
   pub help: String,
 
   /// A list of environment variables that overrides the base environment
+  ///
+  /// BREAKING: Renamed from `environment` in 0.3.0
   #[serde(default)]
-  pub environment: EnvMap,
+  pub variables: VarMap,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -208,7 +212,7 @@ pub struct Type {
 #[derive(Debug)]
 pub struct Task {
   args: Vec<String>,
-  env: Option<EnvMap>,
+  vars: Option<VarMap>,
 }
 
 impl Mold {
@@ -324,8 +328,8 @@ impl Mold {
     }
   }
 
-  pub fn env(&self) -> &EnvMap {
-    &self.data.environment
+  pub fn vars(&self) -> &VarMap {
+    &self.data.variables
   }
 
   pub fn set_env(&mut self, env: Option<String>) {
@@ -527,7 +531,7 @@ impl Mold {
   ///
   /// This entails recursing through various groups to find the the appropriate
   /// Task.
-  pub fn find_task(&self, target_name: &str, prev_env: &EnvMap) -> Result<Option<Task>, Error> {
+  pub fn find_task(&self, target_name: &str, prev_vars: &VarMap) -> Result<Option<Task>, Error> {
     // check if we're executing a nested subrecipe that we'll have to recurse into
     if target_name.contains('/') {
       let splits: Vec<_> = target_name.splitn(2, '/').collect();
@@ -536,22 +540,22 @@ impl Mold {
       let recipe = self.find_recipe(group_name)?;
       let group = self.open_group(group_name)?;
 
-      // merge this moldfile's environment with its parent.
+      // merge this moldfile's variables with its parent.
       // the parent has priority and overrides this moldfile because it's called recursively:
       //   $ mold foo/bar/baz
       // will call bar/baz with foo as the parent, which will call baz with bar as
       // the parent.  we want foo's moldfile to override bar's moldfile to override
       // baz's moldfile, because baz should be the least specialized.
-      let mut env = group.env().clone();
-      env.extend(prev_env.iter().map(|(k, v)| (k.clone(), v.clone())));
+      let mut vars = group.vars().clone();
+      vars.extend(prev_vars.iter().map(|(k, v)| (k.clone(), v.clone())));
 
-      let mut task = group.find_task(recipe_name, &env)?;
+      let mut task = group.find_task(recipe_name, &vars)?;
       if let Some(task) = &mut task {
-        // not sure if this is the right ordering to update environments in, but
+        // not sure if this is the right ordering to update variables in, but
         // it's done here so that parent group's configuration can override one
         // of the subrecipes in the group
-        if let Some(env) = &mut task.env {
-          env.extend(recipe.env().iter().map(|(k, v)| (k.clone(), v.clone())));
+        if let Some(vars) = &mut task.vars {
+          vars.extend(recipe.vars().iter().map(|(k, v)| (k.clone(), v.clone())));
         }
       }
 
@@ -561,12 +565,12 @@ impl Mold {
     // ...not executing subrecipe, so look up the top-level recipe
     let recipe = self.find_recipe(target_name)?;
 
-    // extend the environment with the recipe's environment settings
-    let mut env = prev_env.clone();
-    env.extend(recipe.env().iter().map(|(k, v)| (k.clone(), v.clone())));
+    // extend the variables with the recipe's variables
+    let mut vars = prev_vars.clone();
+    vars.extend(recipe.vars().iter().map(|(k, v)| (k.clone(), v.clone())));
 
     let task = match recipe {
-      Recipe::Command(target) => Some(Task::from_args(&target.command, Some(&env))),
+      Recipe::Command(target) => Some(Task::from_args(&target.command, Some(&vars))),
       Recipe::File(target) => {
         // what the interpreter is for this recipe
         let type_ = self.find_type(&target.type_)?;
@@ -583,7 +587,7 @@ impl Mold {
           None => type_.find(&search_dir, &target_name)?,
         };
 
-        Some(type_.task(&script.to_str().unwrap(), &env))
+        Some(type_.task(&script.to_str().unwrap(), &vars))
       }
       Recipe::Script(target) => {
         // what the interpreter is for this recipe
@@ -597,7 +601,7 @@ impl Mold {
 
         fs::write(&temp_file, &target.script)?;
 
-        Some(type_.task(&temp_file.to_str().unwrap(), &env))
+        Some(type_.task(&temp_file.to_str().unwrap(), &vars))
       }
       Recipe::Group(_) => {
         // this is kinda hacky, but... whatever. it should probably
@@ -704,8 +708,8 @@ impl Task {
     let mut command = process::Command::new(&self.args[0]);
     command.args(&self.args[1..]);
 
-    if let Some(env) = &self.env {
-      command.envs(env);
+    if let Some(vars) = &self.vars {
+      command.envs(vars);
     }
 
     let exit_status = command.spawn().and_then(|mut handle| handle.wait())?;
@@ -727,30 +731,30 @@ impl Task {
   }
 
   /// Print the environment that will be used
-  pub fn print_env(&self) {
+  pub fn print_vars(&self) {
     if self.args.is_empty() {
       return;
     }
 
-    if let Some(env) = &self.env {
-      for (name, value) in env {
+    if let Some(vars) = &self.vars {
+      for (name, value) in vars {
         println!("  {} = \"{}\"", format!("${}", name).bright_cyan(), value);
       }
     }
   }
 
   /// Create a Task from a Vec of strings
-  pub fn from_args(args: &[String], env: Option<&EnvMap>) -> Task {
+  pub fn from_args(args: &[String], vars: Option<&VarMap>) -> Task {
     Task {
       args: args.into(),
-      env: env.map(std::clone::Clone::clone),
+      vars: vars.map(std::clone::Clone::clone),
     }
   }
 }
 
 impl Type {
   /// Create a Task ready to execute a script
-  pub fn task(&self, script: &str, env: &EnvMap) -> Task {
+  pub fn task(&self, script: &str, vars: &VarMap) -> Task {
     let args: Vec<_> = self
       .command
       .iter()
@@ -759,7 +763,7 @@ impl Type {
 
     Task {
       args,
-      env: Some(env.clone()),
+      vars: Some(vars.clone()),
     }
   }
 
@@ -806,12 +810,12 @@ impl Recipe {
   }
 
   /// Return this recipe's environment
-  pub fn env(&self) -> &EnvMap {
+  pub fn vars(&self) -> &VarMap {
     match self {
-      Recipe::File(f) => &f.base.environment,
-      Recipe::Command(c) => &c.base.environment,
-      Recipe::Script(s) => &s.base.environment,
-      Recipe::Group(g) => &g.base.environment,
+      Recipe::File(f) => &f.base.variables,
+      Recipe::Command(c) => &c.base.variables,
+      Recipe::Script(s) => &s.base.variables,
+      Recipe::Group(g) => &g.base.variables,
     }
   }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ pub mod remote;
 pub type RecipeMap = BTreeMap<String, Recipe>;
 pub type IncludeVec = Vec<Include>;
 pub type TypeMap = BTreeMap<String, Type>;
-pub type VarMap = BTreeMap<String, String>;
+pub type VarMap = BTreeMap<String, String>; // TODO maybe down the line this should allow nulls to `unset` a variable
 pub type EnvMap = BTreeMap<String, VarMap>;
 pub type TaskSet = indexmap::IndexSet<String>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -352,11 +352,6 @@ impl Mold {
     }
   }
 
-  /// Return this moldfile's variables
-  pub fn vars(&self) -> &VarMap {
-    &self.data.variables
-  }
-
   /// Return this moldfile's variables with activated environments
   pub fn env_vars(&self) -> VarMap {
     let mut vars = self.data.variables.clone();
@@ -376,11 +371,6 @@ impl Mold {
   /// Return a specific variable map for an environment
   pub fn get_env(&self, name: &str) -> Option<&VarMap> {
     self.env_map().get(name)
-  }
-
-  /// Return the list of selected environments
-  pub fn envs(&self) -> &Vec<String> {
-    &self.envs
   }
 
   pub fn set_env(&mut self, env: Option<String>) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -357,6 +357,17 @@ impl Mold {
     &self.data.variables
   }
 
+  /// Return this moldfile's variables with activated environments as well
+  pub fn env_vars(&self) -> VarMap {
+    let mut vars = self.data.variables.clone();
+    for env_name in &self.envs {
+      if let Some(env) = self.get_env(env_name) {
+        vars.extend(env.iter().map(|(k, v)| (k.clone(), v.clone())));
+      }
+    }
+    vars
+  }
+
   /// Return this moldfile's environment maps
   pub fn env_map(&self) -> &EnvMap {
     &self.data.environments

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -352,12 +352,24 @@ impl Mold {
     }
   }
 
+  /// Return this moldfile's variables
   pub fn vars(&self) -> &VarMap {
     &self.data.variables
   }
 
-  pub fn envs(&self) -> &EnvMap {
+  /// Return this moldfile's environment maps
+  pub fn env_map(&self) -> &EnvMap {
     &self.data.environments
+  }
+
+  /// Return a specific variable map for an environment
+  pub fn get_env(&self, name: &str) -> Option<&VarMap> {
+    self.env_map().get(name)
+  }
+
+  /// Return the list of selected environments
+  pub fn envs(&self) -> &Vec<String> {
+    &self.envs
   }
 
   pub fn set_env(&mut self, env: Option<String>) {
@@ -851,13 +863,18 @@ impl Recipe {
   }
 
   /// Return this recipe's environments
-  pub fn envs(&self) -> &EnvMap {
+  pub fn env_map(&self) -> &EnvMap {
     match self {
       Recipe::File(f) => &f.base.environments,
       Recipe::Command(c) => &c.base.environments,
       Recipe::Script(s) => &s.base.environments,
       Recipe::Group(g) => &g.base.environments,
     }
+  }
+
+  /// Return a specific variable map for an environment
+  pub fn get_env(&self, name: &str) -> Option<&VarMap> {
+    self.env_map().get(name)
   }
 
   /// Set this recipe's root

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -679,9 +679,10 @@ impl Mold {
     Ok(())
   }
 
-  /// Adopt the same clone dir of a parent
+  /// Adopt any attributes from the parent that should be shared
   pub fn adopt(mut self, parent: &Self) -> Self {
     self.clone_dir = parent.clone_dir.clone();
+    self.script_dir = parent.script_dir.clone();
     self
   }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,7 @@ fn main() -> Result<(), ExitFailure> {
 fn run(args: Args) -> Result<(), Error> {
   // load the moldfile
   let mut mold = Mold::discover(&Path::new("."), args.file.clone())?;
+  mold.set_env(args.env);
 
   // early return if we passed a --clean
   if args.clean {

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,10 @@ pub struct Args {
   #[structopt(long = "include", short = "i")]
   pub includes: Vec<Include>,
 
+  /// Which mold environment is running
+  #[structopt(long = "env", short = "e", env = "MOLDENV")]
+  pub env: Option<String>,
+
   /// Fetch new updates for all downloaded remote data
   #[structopt(long = "update", short = "u")]
   pub update: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,10 +111,18 @@ fn run(args: Args) -> Result<(), Error> {
     .collect();
   let targets = mold.find_all_dependencies(&targets_set)?;
 
+  // prepare environment variables
+  let mut vars = mold.vars().clone();
+  for env_name in mold.envs() {
+    if let Some(env) = mold.get_env(env_name) {
+      vars.extend(env.iter().map(|(k, v)| (k.clone(), v.clone())));
+    }
+  }
+
   // generate a Task for each target
   let mut tasks = vec![];
   for target_name in &targets {
-    if let Some(task) = mold.find_task(&target_name, mold.vars())? {
+    if let Some(task) = mold.find_task(&target_name, &vars)? {
       tasks.push(task);
     }
   }

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,18 +111,10 @@ fn run(args: Args) -> Result<(), Error> {
     .collect();
   let targets = mold.find_all_dependencies(&targets_set)?;
 
-  // prepare environment variables
-  let mut vars = mold.vars().clone();
-  for env_name in mold.envs() {
-    if let Some(env) = mold.get_env(env_name) {
-      vars.extend(env.iter().map(|(k, v)| (k.clone(), v.clone())));
-    }
-  }
-
   // generate a Task for each target
   let mut tasks = vec![];
   for target_name in &targets {
-    if let Some(task) = mold.find_task(&target_name, &vars)? {
+    if let Some(task) = mold.find_task(&target_name, &mold.env_vars())? {
       tasks.push(task);
     }
   }

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,7 +114,7 @@ fn run(args: Args) -> Result<(), Error> {
   // generate a Task for each target
   let mut tasks = vec![];
   for target_name in &targets {
-    if let Some(task) = mold.find_task(&target_name, mold.env())? {
+    if let Some(task) = mold.find_task(&target_name, mold.vars())? {
       tasks.push(task);
     }
   }
@@ -123,7 +123,7 @@ fn run(args: Args) -> Result<(), Error> {
   for task in &tasks {
     task.print_cmd();
     if args.dry {
-      task.print_env();
+      task.print_vars();
     } else {
       task.exec()?;
     }


### PR DESCRIPTION
This breaks any previous moldfiles that relied on the `environment` attributes, because that's been replaced with `variables`.

In addition, it adds an `environments` attribute to the global moldfile as well as at a recipe level. This field contains a list of environment labels and corresponding variable maps. Environments can then be selected as a comma-separated list via the `--env` / `-e` CLI flags or the `$MOLDENV` environment variable. For each selected environment, the current variable map will be updated with the corresponding environment's variable map.