### PR TITLE
Add expressions for environment checks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ exitfailure = "0.5"
 failure = "0.1"
 git2 = "0.8"
 indexmap = {version = "1.0", features = ["serde-1"]}
-itertools = "0.8"
 log = "0.4"
 semver = "0.9"
 serde = "1.0"

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -27,7 +27,7 @@ pub enum Expr {
 }
 
 impl Expr {
-  pub fn apply(&self, to: &Vec<String>) -> bool {
+  pub fn apply(&self, to: &[String]) -> bool {
     match self {
       Expr::And(x, y) => x.apply(to) && y.apply(to),
       Expr::Or(x, y) => x.apply(to) || y.apply(to),

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1,0 +1,98 @@
+use std::iter::Enumerate;
+use std::iter::Peekable;
+use std::str::Chars;
+
+type CharIter<'a> = Peekable<Enumerate<Chars<'a>>>;
+
+#[derive(Debug, Clone)]
+enum Token {
+  And,
+  Or,
+  Not,
+  Pal,
+  Par,
+  Name(String),
+}
+
+#[derive(Debug, Clone)]
+pub enum Expr {
+  And(Box<Expr>, Box<Expr>),
+  Or(Box<Expr>, Box<Expr>),
+  Not(Box<Expr>),
+  Group(Box<Expr>),
+  Val(String),
+}
+
+impl Expr {
+  pub fn apply(to: &[&str]) -> bool {
+    false
+  }
+}
+
+fn lex_name(it: &mut CharIter) -> Token {
+  let mut name = String::new();
+  name.push(it.next().unwrap().1);
+
+  while let Some(&(_i, c)) = it.peek() {
+    match c {
+      'a'...'z' | 'A'...'Z' | '0'...'9' | '_' | '-' => {
+        it.next();
+        name.push(c);
+      }
+      _ => break,
+    }
+  }
+
+  Token::Name(name)
+}
+
+fn lex(expr: &str) -> Vec<Token> {
+  let mut tokens = vec![];
+  let mut it: CharIter = expr.chars().enumerate().peekable();
+
+  while let Some(&(_i, c)) = it.peek() {
+    let x = match c {
+      'a'...'z' | 'A'...'Z' | '0'...'9' | '_' | '-' => Some(lex_name(&mut it)),
+      '+' => {
+        it.next();
+        Some(Token::And)
+      }
+      '|' => {
+        it.next();
+        Some(Token::Or)
+      }
+      '~' => {
+        it.next();
+        Some(Token::Not)
+      }
+      '(' => {
+        it.next();
+        Some(Token::Pal)
+      }
+      ')' => {
+        it.next();
+        Some(Token::Par)
+      }
+      ' ' | '\t' | '\n' => {
+        it.next();
+        None
+      }
+      _ => {
+        it.next();
+        None
+      }
+    };
+    if let Some(token) = x {
+      tokens.push(token);
+    }
+  }
+
+  tokens
+}
+
+fn parse() {}
+
+pub fn compile(expr: &str) -> Expr {
+  dbg!(lex(expr));
+  Expr::Val("foo".into())
+}

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -27,8 +27,14 @@ pub enum Expr {
 }
 
 impl Expr {
-  pub fn apply(to: &[&str]) -> bool {
-    false
+  pub fn apply(&self, to: &Vec<String>) -> bool {
+    match self {
+      Expr::And(x, y) => x.apply(to) && y.apply(to),
+      Expr::Or(x, y) => x.apply(to) || y.apply(to),
+      Expr::Not(x) => !x.apply(to),
+      Expr::Group(x) => x.apply(to),
+      Expr::Atom(x) => to.contains(x),
+    }
   }
 }
 
@@ -106,7 +112,7 @@ fn parse_atom(it: &mut TokenIter) -> Result<Expr, Error> {
     }
     Some(Token::Name(x)) => {
       it.next();
-      Ok(Expr::Atom(x.to_string()))
+      Ok(Expr::Atom(x.clone()))
     }
     _ => Err(err_msg("Parse error; expected name or open parenthesis")),
   }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -14,6 +14,7 @@ enum Token {
   Not,
   Pal,
   Par,
+  Wild,
   Name(String),
 }
 
@@ -24,6 +25,7 @@ pub enum Expr {
   Not(Box<Expr>),
   Group(Box<Expr>),
   Atom(String),
+  Wild,
 }
 
 impl Expr {
@@ -34,6 +36,7 @@ impl Expr {
       Expr::Not(x) => !x.apply(to),
       Expr::Group(x) => x.apply(to),
       Expr::Atom(x) => to.contains(x),
+      Expr::Wild => true,
     }
   }
 }
@@ -101,6 +104,10 @@ fn parse_atom(it: &mut TokenIter) -> Result<Expr, Error> {
       it.next();
       Ok(Expr::Atom(x.clone()))
     }
+    Some(Token::Wild) => {
+      it.next();
+      Ok(Expr::Wild)
+    }
     _ => Err(err_msg("Parse error; expected name or open parenthesis")),
   }
 }
@@ -119,6 +126,10 @@ fn lex(expr: &str) -> Vec<Token> {
       '|' => {
         it.next();
         Some(Token::Or)
+      }
+      '*' | '?' => {
+        it.next();
+        Some(Token::Wild)
       }
       '~' => {
         it.next();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ use std::process;
 use std::str::FromStr;
 use std::string::ToString;
 
+pub mod expr;
 pub mod remote;
 pub mod util;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -360,7 +360,7 @@ impl Mold {
   /// Environment tests are parsed as expressions and evaluated against the
   /// list of environments. Environments that evaluate to true are added to the
   /// returned list; environments that evaluate to false are ignored.
-  fn cross_envs(&self) -> Vec<String> {
+  fn active_envs(&self) -> Vec<String> {
     let mut result = vec![];
     for (test, _) in &self.data.environments {
       match expr::compile(&test) {
@@ -379,7 +379,7 @@ impl Mold {
   /// Return this moldfile's variables with activated environments
   pub fn env_vars(&self) -> VarMap {
     let mut vars = self.data.variables.clone();
-    for env_name in self.cross_envs() {
+    for env_name in self.active_envs() {
       if let Some(env) = self.data.environments.get(&env_name) {
         vars.extend(env.iter().map(|(k, v)| (k.clone(), v.clone())));
       }
@@ -623,7 +623,7 @@ impl Mold {
         if let Some(vars) = &mut task.vars {
           vars.extend(
             recipe
-              .env_vars(&self.cross_envs())
+              .env_vars(&self.active_envs())
               .iter()
               .map(|(k, v)| (k.clone(), v.clone())),
           );
@@ -640,7 +640,7 @@ impl Mold {
     let mut vars = prev_vars.clone();
     vars.extend(
       recipe
-        .env_vars(&self.cross_envs())
+        .env_vars(&self.active_envs())
         .iter()
         .map(|(k, v)| (k.clone(), v.clone())),
     );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -361,10 +361,18 @@ impl Mold {
   /// eg, given environments {a, b, c}, this will yield:
   ///    a, b, c, a+b, b+a, a+c, c+a, b+c, c+b, etc...
   fn cross_envs(&self) -> Vec<String> {
-    util::all_permutations(&self.envs)
-      .iter()
-      .map(|x| x.iter().join("+"))
-      .collect()
+    let mut result = vec![];
+    for (test, _) in &self.data.environments {
+      let ex = expr::compile(&test);
+
+      // ignore errors, I guess
+      if let Ok(ex) = ex {
+        if ex.apply(&self.envs) {
+          result.push(test.clone());
+        }
+      }
+    }
+    result
   }
 
   /// Return this moldfile's variables with activated environments

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -355,21 +355,22 @@ impl Mold {
     }
   }
 
-  /// Generate a list of all permutations of the activated environments
+  /// Generate a list of all active environments
   ///
-  /// Environments are yielded as strings joined by plus signs.
-  /// eg, given environments {a, b, c}, this will yield:
-  ///    a, b, c, a+b, b+a, a+c, c+a, b+c, c+b, etc...
+  /// Environment tests are parsed as expressions and evaluated against the
+  /// list of environments. Environments that evaluate to true are added to the
+  /// returned list; environments that evaluate to false are ignored.
   fn cross_envs(&self) -> Vec<String> {
     let mut result = vec![];
     for (test, _) in &self.data.environments {
-      let ex = expr::compile(&test);
-
-      // ignore errors, I guess
-      if let Ok(ex) = ex {
-        if ex.apply(&self.envs) {
-          result.push(test.clone());
+      match expr::compile(&test) {
+        Ok(ex) =>  {
+          if ex.apply(&self.envs) {
+            result.push(test.clone());
+          }
         }
+        // FIXME this error handling should probably be better
+        Err(err) => println!("{}: '{}': {}", "Warning".bright_red(), test, err),
       }
     }
     result

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@ use colored::*;
 use failure::Error;
 use indexmap::IndexMap;
 use indexmap::IndexSet;
-use itertools::Itertools;
 use semver::Version;
 use semver::VersionReq;
 use serde_derive::Deserialize;
@@ -364,7 +363,7 @@ impl Mold {
     let mut result = vec![];
     for (test, _) in &self.data.environments {
       match expr::compile(&test) {
-        Ok(ex) =>  {
+        Ok(ex) => {
           if ex.apply(&self.envs) {
             result.push(test.clone());
           }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,3 @@
-use itertools::Itertools;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::Hash;
 use std::hash::Hasher;
@@ -11,62 +10,4 @@ pub fn hash_string(string: &str) -> String {
   let mut hasher = DefaultHasher::new();
   string.hash(&mut hasher);
   format!("{:16x}", hasher.finish())
-}
-
-struct Permutations {
-  idxs: Vec<usize>,
-  swaps: Vec<usize>,
-  i: usize,
-}
-
-impl Permutations {
-  pub fn new(size: usize) -> Self {
-    Self {
-      idxs: (0..size).collect(),
-      swaps: vec![0; size],
-      i: 0,
-    }
-  }
-}
-
-impl Iterator for Permutations {
-  type Item = Vec<usize>;
-
-  fn next(&mut self) -> Option<Self::Item> {
-    if self.i > 0 {
-      loop {
-        if self.i >= self.swaps.len() {
-          return None;
-        }
-        if self.swaps[self.i] < self.i {
-          break;
-        }
-        self.swaps[self.i] = 0;
-        self.i += 1;
-      }
-      self.idxs.swap(self.i, (self.i & 1) * self.swaps[self.i]);
-      self.swaps[self.i] += 1;
-    }
-    self.i = 1;
-    Some(self.idxs.clone())
-  }
-}
-
-fn apply_permutation<T: Clone>(idx: &[usize], to: &[T]) -> Vec<T> {
-  idx.iter().map(|x| to[*x].clone()).collect()
-}
-
-pub fn all_permutations<T>(of: &[T]) -> Vec<Vec<&T>> {
-  let mut result = vec![];
-
-  for n in 1..=of.len() {
-    for combo in of.iter().combinations(n) {
-      let perms = Permutations::new(combo.len());
-      for perm in perms {
-        result.push(apply_permutation(&perm, &combo));
-      }
-    }
-  }
-
-  result
 }


### PR DESCRIPTION
This replaces the previous permutation implementation with a more robust expression-based system. Environment tests are simple expressions composed of boolean operations used to check containment within the environment list supplied by `$MOLDENV` / `-e` / `-a`.

Mini-spec:
* `x` checks if `x` is contained in the environment list
* `~x` returns the opposite of `x`
* `x + y` returns `x` *and* `y`
* `x | y` returns `x` *or* `y`
* `()` can be used to group operations; eg: `~(x | y)` returns true if `x` and `y` are both absent from the list
* `*` can be used as a wildcard that always returns true. It might be useful if `variables` is deprecated later; I'm not sure yet