### PR TITLE
Attempt clones w/ https:// prefix before orig URL

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -547,7 +547,7 @@ impl Mold {
   ) -> Result<(), Error> {
     let path = self.clone_dir.join(folder_name);
     if !path.is_dir() {
-      remote::clone(url, &path)?;
+      remote::clone(&format!("https://{}", url), &path).or_else(|_| remote::clone(url, &path))?;
       remote::checkout(&path, ref_)?;
 
       // open it and recursively clone + merge


### PR DESCRIPTION
See #24 

It tries to clone with `https://` prefixed first, then if it fails it will try the actual URL. Seems to work well because the prefixed clone usually fails without any of the remote callbacks being called.