### PR TITLE
0.4.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_yaml = "0.8"
 structopt = "0.3"
-toml = "0.5"
 
 [[bin]]
 name = "mold"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mold"
-version = "0.3.2"
+version = "0.4.0"
 authors = [
   "John Weachock <jweachock@gmail.com>",
   "Philip Dexter <philip.dexter@gmail.com>",

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ TODO finish more
   * command
   * script
   * file
-  * group
-* types
+  * modules
+* runtimes
 * includes
 * variables
 * environments

--- a/mold.sh
+++ b/mold.sh
@@ -3,7 +3,7 @@
 # all arguments through to it. This simplifies usage on CI/CD platforms as well
 # as for users who haven't installed mold yet.
 
-VER="0.3.2"
+VER="0.4.0"
 EXE="./.mold-$VER"
 URL="https://github.com/xtfc/mold/releases/download/v$VER/mold-$VER"
 

--- a/mold.yaml
+++ b/mold.yaml
@@ -2,8 +2,9 @@ version: "0.4.0"
 
 includes:
   - url: "github.com/xtfc/std.mold"
+    ref: "0.4"
   - url: "github.com/xtfc/cargo.mold"
-    ref: "v2"
+    ref: "v3"
 
 runtimes:
   python:

--- a/mold.yaml
+++ b/mold.yaml
@@ -1,11 +1,11 @@
-version: "0.3.2"
+version: "0.4.0"
 
 includes:
   - url: "github.com/xtfc/std.mold"
   - url: "github.com/xtfc/cargo.mold"
     ref: "v2"
 
-types:
+runtimes:
   python:
     command: ["python", "?"]
     extensions: ["py"]
@@ -13,28 +13,28 @@ types:
 recipes:
   staticbuild:
     help: "Build a static MUSL binary using Docker"
-    type: "sh"
+    runtime: "sh"
 
   python:
-    type: "python"
+    runtime: "python"
 
   python-file:
-    type: "python"
+    runtime: "python"
     file: "python.py"
 
   python-script:
-    type: "python"
+    runtime: "python"
     script: |
       print("Hello, world!")
 
   shell:
-    type: "sh"
+    runtime: "sh"
 
   shell-file:
-    type: "sh"
+    runtime: "sh"
     file: "shell.sh"
 
   shell-script:
-    type: "sh"
+    runtime: "sh"
     script: |
       echo "Hello, world!"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,7 +175,7 @@ pub struct RecipeBase {
   ///
   /// ADDED: 0.4.0
   #[serde(default)]
-  pub workdir: Option<PathBuf>,
+  pub work_dir: Option<PathBuf>,
 
   /// The actual search_dir of this recipe
   ///
@@ -273,7 +273,7 @@ pub struct Command {
 pub struct Task {
   args: Vec<String>,
   vars: Option<VarMap>,
-  workdir: PathBuf,
+  work_dir: PathBuf,
 }
 
 impl Mold {
@@ -892,7 +892,7 @@ impl FromStr for Include {
 
 impl Runtime {
   /// Create a Task ready to execute a script
-  fn task(&self, script: &str, vars: &VarMap, workdir: &PathBuf) -> Task {
+  fn task(&self, script: &str, vars: &VarMap, work_dir: &PathBuf) -> Task {
     let args: Vec<_> = self
       .command
       .iter()
@@ -901,7 +901,7 @@ impl Runtime {
 
     Task {
       args,
-      workdir: workdir.clone(),
+      work_dir: work_dir.clone(),
       vars: Some(vars.clone()),
     }
   }
@@ -985,10 +985,10 @@ impl Recipe {
   /// Return this recipe's working directory
   fn work_dir(&self) -> &Option<PathBuf> {
     match self {
-      Recipe::File(f) => &f.base.workdir,
-      Recipe::Command(c) => &c.base.workdir,
-      Recipe::Script(s) => &s.base.workdir,
-      Recipe::Module(g) => &g.base.workdir,
+      Recipe::File(f) => &f.base.work_dir,
+      Recipe::Command(c) => &c.base.work_dir,
+      Recipe::Script(s) => &s.base.work_dir,
+      Recipe::Module(g) => &g.base.work_dir,
     }
   }
 
@@ -1029,7 +1029,7 @@ impl Task {
 
     let mut command = process::Command::new(&self.args[0]);
     command.args(&self.args[1..]);
-    command.current_dir(&self.workdir);
+    command.current_dir(&self.work_dir);
 
     if let Some(vars) = &self.vars {
       command.envs(vars);
@@ -1067,11 +1067,11 @@ impl Task {
   }
 
   /// Create a Task from a Vec of strings
-  fn from_args(args: &[String], vars: Option<&VarMap>, workdir: &PathBuf) -> Task {
+  fn from_args(args: &[String], vars: Option<&VarMap>, work_dir: &PathBuf) -> Task {
     Task {
       args: args.into(),
       vars: vars.map(std::clone::Clone::clone),
-      workdir: workdir.clone(),
+      work_dir: work_dir.clone(),
     }
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,9 @@ pub struct Mold {
   /// path to the recipe scripts
   dir: PathBuf,
 
+  /// (derived) root directory that the file sits in
+  root_dir: PathBuf,
+
   /// (derived) path to the cloned repos
   clone_dir: PathBuf,
 
@@ -288,6 +291,7 @@ impl Mold {
     }
 
     let dir = path.with_file_name(&data.recipe_dir);
+    let root_dir = dir.parent().unwrap_or(&Path::new("/")).to_path_buf();
     let clone_dir = dir.join(".clones");
     let script_dir = dir.join(".scripts");
 
@@ -304,6 +308,7 @@ impl Mold {
     Ok(Mold {
       file: fs::canonicalize(path)?,
       dir: fs::canonicalize(dir)?,
+      root_dir: fs::canonicalize(root_dir)?,
       clone_dir: fs::canonicalize(clone_dir)?,
       script_dir: fs::canonicalize(script_dir)?,
       envs: vec![],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ pub type EnvMap = IndexMap<String, VarMap>;
 pub type RecipeMap = BTreeMap<String, Recipe>; // sorted alphabetically
 pub type RuntimeMap = BTreeMap<String, Runtime>; // sorted alphabetically
 
-const MOLD_FILES: &[&str] = &["mold.toml", "mold.yaml", "moldfile", "Moldfile"];
+const MOLD_FILES: &[&str] = &["mold.yaml", "mold.yml", "moldfile", "Moldfile"];
 
 fn default_recipe_dir() -> PathBuf {
   "./mold".into()
@@ -282,11 +282,7 @@ impl Mold {
     let mut contents = String::new();
     file.read_to_string(&mut contents)?;
 
-    let data: Moldfile = match path.extension().and_then(OsStr::to_str) {
-      Some("yaml") | Some("yml") => serde_yaml::from_str(&contents)?,
-      _ => toml::de::from_str(&contents)?,
-    };
-
+    let data: Moldfile = serde_yaml::from_str(&contents)?;
     let self_version = Version::parse(clap::crate_version!())?;
     let target_version = match data.version {
       Some(ref version) => VersionReq::parse(&version)?,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -657,6 +657,15 @@ impl Mold {
         .map(|(k, v)| (k.clone(), v.clone())),
     );
 
+    let root = recipe
+      .root()
+      .clone()
+      .unwrap_or(self.dir.clone())
+      .to_str()
+      .unwrap()
+      .into();
+    vars.insert("MOLD_ROOT".into(), root);
+
     let task = match recipe {
       Recipe::Command(target) => Some(Task::from_args(&target.command, Some(&vars))),
       Recipe::File(target) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,9 @@ pub struct Moldfile {
   #[serde(default)]
   pub recipes: RecipeMap,
 
-  /// A map of interpreter types and characteristics
+  /// A map of interpreter runtimes and characteristics
+  ///
+  /// BREAKING: Renamed from `types` in 0.4.0
   #[serde(default)]
   pub runtimes: RuntimeMap,
 
@@ -215,6 +217,8 @@ pub struct File {
   pub deps: Vec<String>,
 
   /// Which interpreter should be used to execute this script
+  ///
+  /// BREAKING: Renamed from `type` in 0.4.0
   pub runtime: String,
 
   /// The script file name
@@ -236,6 +240,8 @@ pub struct Script {
   pub deps: Vec<String>,
 
   /// Which interpreter should be used to execute this script
+  ///
+  /// BREAKING: Renamed from `type` in 0.4.0
   pub runtime: String,
 
   /// The script contents as a multiline string

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -637,7 +637,7 @@ impl Mold {
       let recipe = self.find_recipe(module_name)?;
       let module = self.open_module(module_name)?;
 
-      // merge this moldfile's variables with its parent.
+      // merge this moldfile's variables with its parent, ie the caller.
       // the parent has priority and overrides this moldfile because it's called recursively:
       //   $ mold foo/bar/baz
       // will call bar/baz with foo as the parent, which will call baz with bar as
@@ -679,6 +679,8 @@ impl Mold {
     // use the target's search_dir, but fall back to our own
     // (feels like I shouldn't have to clone these, though...)
     let search_dir = recipe.search_dir().clone().unwrap_or(self.dir.clone());
+
+    // join the target's work_dir to our root_dir, or just pick our root_dir
     let work_dir = match recipe.work_dir() {
       None => self.root_dir.clone(),
       Some(val) => self.root_dir.join(val),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,6 @@ use serde_derive::Deserialize;
 use serde_derive::Serialize;
 use std::collections::BTreeMap;
 use std::collections::HashSet;
-use std::ffi::OsStr;
 use std::fs;
 use std::io::prelude::*;
 use std::path::Path;
@@ -678,7 +677,10 @@ impl Mold {
 
     // use the target's search_dir, but fall back to our own
     // (feels like I shouldn't have to clone these, though...)
-    let search_dir = recipe.search_dir().clone().unwrap_or(self.dir.clone());
+    let search_dir = recipe
+      .search_dir()
+      .clone()
+      .unwrap_or_else(|| self.dir.clone());
 
     // join the target's work_dir to our root_dir, or just pick our root_dir
     let work_dir = match recipe.work_dir() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -685,6 +685,10 @@ impl Mold {
     };
 
     vars.insert(
+      "MOLD_MODULE_ROOT".into(),
+      self.root_dir.to_str().unwrap().into(),
+    );
+    vars.insert(
       "MOLD_SEARCH_DIR".into(),
       search_dir.to_str().unwrap().into(),
     );


### PR DESCRIPTION
* **BREAKING** Resolve #26
  * `Group` => `Module`, `Type` => `Runtime` and respective fields in `Moldfile` / `Recipe`s.
* Resolve #21 
  * `$MOLD_SEARCH_DIR` now points to the directory that will be searched for recipe files.
  * `$MOLD_DIR` now points to the `.dir` attribute of the root `Moldfile`
  * `$MOLD_ROOT` now points to the containing directory of the root `Moldfile`
  * `$MOLD_MODULE_ROOT` now points to the containing directory of the current recipe's `Moldfile`
* Resolve #20 
  * Add `work_dir` to `RecipeBase`, but it only works for non-`Module` recipes. `Module`s are slightly trickier because of the recursion...
* Close #23 
  * See https://github.com/xtfc/mold/issues/23#issuecomment-534820261