### PR TITLE
Reject invalid moldfiles and make `version` non-optional

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -28,6 +28,7 @@ fn default_git_ref() -> String {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Moldfile {
   /// Version of mold required to run this Moldfile
   pub version: Option<String>,

--- a/src/file.rs
+++ b/src/file.rs
@@ -31,7 +31,7 @@ fn default_git_ref() -> String {
 #[serde(deny_unknown_fields)]
 pub struct Moldfile {
   /// Version of mold required to run this Moldfile
-  pub version: Option<String>,
+  pub version: String,
 
   /// The directory that recipe scripts can be found in
   #[serde(default = "default_recipe_dir")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,10 +79,7 @@ impl Mold {
 
     let data: Moldfile = serde_yaml::from_str(&contents)?;
     let self_version = Version::parse(clap::crate_version!())?;
-    let target_version = match data.version {
-      Some(ref version) => VersionReq::parse(&version)?,
-      None => VersionReq::parse(clap::crate_version!())?,
-    };
+    let target_version = VersionReq::parse(&data.version)?;
 
     if !target_version.matches(&self_version) {
       return Err(failure::format_err!(


### PR DESCRIPTION
Fix #38 