### PR TITLE
Remove Command and Module recipes

### DIFF
--- a/mold.yaml
+++ b/mold.yaml
@@ -1,12 +1,11 @@
-version: "0.5"
+version: "0.6"
 
 includes:
-  - url: "github.com/xtfc/std.mold"
-    ref: "0.5"
   - url: "github.com/xtfc/cargo.mold"
-    ref: "v4"
+    ref: "dev"
+    prefix: "c/"
 
 recipes:
   staticbuild:
     help: "Build a static MUSL binary using Docker"
-    runtime: "sh"
+    shell: "$SHELL $MOLD_DIR/staticbuild.sh"

--- a/src/file.rs
+++ b/src/file.rs
@@ -8,7 +8,7 @@ use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 // sorted by insertion order
-pub type IncludeVec = Vec<Remote>;
+pub type IncludeVec = Vec<Include>;
 pub type TargetSet = IndexSet<String>;
 pub type VarMap = IndexMap<String, String>; // TODO maybe down the line this should allow nulls to `unset` a variable
 pub type EnvMap = IndexMap<String, VarMap>;
@@ -69,6 +69,18 @@ pub struct Remote {
 
   /// Moldfile to look at
   pub file: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Include {
+  /// Remote to include
+  #[serde(flatten)]
+  pub remote: Remote,
+
+  /// Prefix to prepend
+  #[serde(default)]
+  pub prefix: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/file.rs
+++ b/src/file.rs
@@ -72,7 +72,7 @@ pub struct Remote {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RecipeBase {
+pub struct Recipe {
   /// A short description of the module's contents
   #[serde(default)]
   pub help: String,
@@ -103,42 +103,6 @@ pub struct RecipeBase {
   #[serde(skip)]
   pub search_dir: Option<PathBuf>,
 
-  /// The module path that led to this recipe existing
-  ///
-  /// This is used for explanations as well as creating the environment
-  /// variables.
-  #[serde(skip)]
-  pub mod_list: Vec<Module>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum Recipe {
-  // apparently the order here matters?
-  Shell(Shell),
-  Command(Command),
-  Module(Module),
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct Module {
-  /// Base data
-  #[serde(flatten)]
-  pub base: RecipeBase,
-
-  /// Remote data
-  #[serde(flatten)]
-  pub remote: Remote,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct Shell {
-  /// Base data
-  #[serde(flatten)]
-  pub base: RecipeBase,
-
   /// A list of pre-execution dependencies
   #[serde(default)]
   pub deps: Vec<String>,
@@ -153,19 +117,4 @@ pub struct Shell {
   ///
   /// Its contents will be written to a file pointed to by $MOLD_SCRIPT
   pub script: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct Command {
-  /// Base data
-  #[serde(flatten)]
-  pub base: RecipeBase,
-
-  /// A list of pre-execution dependencies
-  #[serde(default)]
-  pub deps: Vec<String>,
-
-  /// A list of command arguments
-  pub command: Vec<String>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,19 +233,7 @@ impl Mold {
     let mut new_targets = TargetSet::new();
 
     for target_name in targets {
-      // we need to ensure that any dependencies are local to the target's module
-      if target_name.contains('/') {
-        let split: Vec<_> = target_name.rsplitn(2, '/').collect();
-        new_targets.extend(
-          self
-            .find_dependencies(target_name)?
-            .iter()
-            .map(|x| format!("{}/{}", split[1], x)),
-        );
-      } else {
-        new_targets.extend(self.find_dependencies(target_name)?);
-      };
-
+      new_targets.extend(self.find_dependencies(target_name)?);
       new_targets.insert(target_name.clone());
     }
 
@@ -594,10 +582,13 @@ impl Moldfile {
   /// Merges any recipes from `other` that aren't in `self`
   pub fn merge(&mut self, other: Mold, prefix: &str) {
     for (recipe_name, recipe) in other.data.recipes {
+      let mut new_recipe = recipe.clone();
+      new_recipe.deps = new_recipe.deps.iter().map(|x| format!("{}{}", prefix, x)).collect();
+
       self
         .recipes
         .entry(format!("{}{}", prefix, recipe_name))
-        .or_insert(recipe);
+        .or_insert(new_recipe);
     }
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -583,7 +583,11 @@ impl Moldfile {
   pub fn merge(&mut self, other: Mold, prefix: &str) {
     for (recipe_name, recipe) in other.data.recipes {
       let mut new_recipe = recipe.clone();
-      new_recipe.deps = new_recipe.deps.iter().map(|x| format!("{}{}", prefix, x)).collect();
+      new_recipe.deps = new_recipe
+        .deps
+        .iter()
+        .map(|x| format!("{}{}", prefix, x))
+        .collect();
 
       self
         .recipes


### PR DESCRIPTION
`Command`s were just more difficult to write than regular shell/script recipes. I do hear that the the list form is more useful and predictable for cross-platform support, but for now I don't care.

`Module`s have been replaced in favor of prefixed includes.

Close #59 