### PR TITLE
Remove mold directory

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -18,10 +18,6 @@ pub type RecipeMap = BTreeMap<String, Recipe>; // sorted alphabetically
 
 pub const DEFAULT_FILES: &[&str] = &["mold.yaml", "mold.yml", "moldfile", "Moldfile"];
 
-fn default_recipe_dir() -> PathBuf {
-  "./mold".into()
-}
-
 fn default_git_ref() -> String {
   "master".into()
 }
@@ -31,10 +27,6 @@ fn default_git_ref() -> String {
 pub struct Moldfile {
   /// Version of mold required to run this Moldfile
   pub version: String,
-
-  /// The directory that recipe scripts can be found in
-  #[serde(default = "default_recipe_dir")]
-  pub recipe_dir: PathBuf,
 
   /// A map of includes
   #[serde(default)]
@@ -107,13 +99,6 @@ pub struct Recipe {
   /// ADDED: 0.4.0
   #[serde(default)]
   pub work_dir: Option<PathBuf>,
-
-  /// The actual search_dir of this recipe
-  ///
-  /// This is used for Includes, where the command may be lifted up to the
-  /// top-level, but the search_dir is located in a different location
-  #[serde(skip)]
-  pub search_dir: Option<PathBuf>,
 
   /// A list of pre-execution dependencies
   #[serde(default)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,11 +51,8 @@ pub struct Mold {
   /// (derived) root directory that the file sits in
   root_dir: PathBuf,
 
-  /// (derived) path to the cloned repos
-  clone_dir: PathBuf,
-
-  /// (derived) path to the generated scripts
-  script_dir: PathBuf,
+  /// (derived) path to the cloned repos and generated scripts
+  mold_dir: PathBuf,
 
   /// which environments to use in the environment
   envs: Vec<String>,
@@ -87,24 +84,15 @@ impl Mold {
 
     let root_dir = path.parent().unwrap_or(&Path::new("/")).to_path_buf();
     let mold_dir = root_dir.join(".mold");
-    let clone_dir = mold_dir.join("clones");
-    let script_dir = mold_dir.join("scripts");
 
     if !mold_dir.is_dir() {
       fs::create_dir(&mold_dir)?;
-    }
-    if !clone_dir.is_dir() {
-      fs::create_dir(&clone_dir)?;
-    }
-    if !script_dir.is_dir() {
-      fs::create_dir(&script_dir)?;
     }
 
     Ok(Mold {
       file: fs::canonicalize(path)?,
       root_dir: fs::canonicalize(root_dir)?,
-      clone_dir: fs::canonicalize(clone_dir)?,
-      script_dir: fs::canonicalize(script_dir)?,
+      mold_dir: fs::canonicalize(mold_dir)?,
       envs: vec![],
       data,
     })
@@ -219,7 +207,7 @@ impl Mold {
   }
 
   fn open_remote(&self, target: &Remote) -> Result<Mold, Error> {
-    let path = self.clone_dir.join(&target.folder_name());
+    let path = self.mold_dir.join(&target.folder_name());
     let mut mold = Self::discover(&path, target.file.clone())?.adopt(self);
     mold.process_includes()?;
     Ok(mold)
@@ -291,8 +279,7 @@ impl Mold {
 
     vars.insert("MOLD_ROOT", self.root_dir.to_string_lossy());
     vars.insert("MOLD_FILE", self.file.to_string_lossy());
-    vars.insert("MOLD_CLONE_DIR", self.clone_dir.to_string_lossy());
-    vars.insert("MOLD_SCRIPT_DIR", self.script_dir.to_string_lossy());
+    vars.insert("MOLD_DIR", self.mold_dir.to_string_lossy());
 
     if let Some(script) = self.script_name(target_name)? {
       // what the fuck is going on here?
@@ -312,7 +299,7 @@ impl Mold {
   pub fn script_name(&self, target_name: &str) -> Result<Option<PathBuf>, Error> {
     let target = self.find_recipe(target_name)?;
     if let Some(script) = &target.script {
-      let file = self.script_dir.join(util::hash_string(&script));
+      let file = self.mold_dir.join(util::hash_string(&script));
       fs::write(&file, &script)?;
       Ok(Some(file))
     } else {
@@ -331,7 +318,7 @@ impl Mold {
     ref_: &str,
     file: Option<PathBuf>,
   ) -> Result<(), Error> {
-    let path = self.clone_dir.join(folder_name);
+    let path = self.mold_dir.join(folder_name);
     if !path.is_dir() {
       remote::clone(&format!("https://{}", url), &path).or_else(|_| remote::clone(url, &path))?;
       remote::checkout(&path, ref_)?;
@@ -370,7 +357,7 @@ impl Mold {
   /// * fetch / checkout
   /// * recurse into it
   fn update_remote(&self, remote: &Remote, updated: &mut HashSet<PathBuf>) -> Result<(), Error> {
-    let path = self.clone_dir.join(remote.folder_name());
+    let path = self.mold_dir.join(remote.folder_name());
     if path.is_dir() && !updated.contains(&path) {
       updated.insert(path.clone());
       remote::checkout(&path, &remote.ref_)?;
@@ -402,11 +389,8 @@ impl Mold {
   /// Delete all cloned top-level targets
   pub fn clean_all(&self) -> Result<(), Error> {
     // no point in checking if it exists, because Mold::open creates it
-    fs::remove_dir_all(&self.clone_dir)?;
-    println!("{:>12} {}", "Deleted".red(), self.clone_dir.display());
-
-    fs::remove_dir_all(&self.script_dir)?;
-    println!("{:>12} {}", "Deleted".red(), self.script_dir.display());
+    fs::remove_dir_all(&self.mold_dir)?;
+    println!("{:>12} {}", "Deleted".red(), self.mold_dir.display());
     Ok(())
   }
 
@@ -417,7 +401,7 @@ impl Mold {
     // mutated while iterating through one of its fields.
     let mut others = vec![];
     for include in &self.data.includes {
-      let path = self.clone_dir.join(include.remote.folder_name());
+      let path = self.mold_dir.join(include.remote.folder_name());
       let mut other = Self::discover(&path, include.remote.file.clone())?.adopt(self);
 
       // recursively merge
@@ -434,8 +418,7 @@ impl Mold {
 
   /// Adopt any attributes from the parent that should be shared
   fn adopt(mut self, parent: &Self) -> Self {
-    self.clone_dir = parent.clone_dir.clone();
-    self.script_dir = parent.script_dir.clone();
+    self.mold_dir = parent.mold_dir.clone();
     self.envs = parent.envs.clone();
     self
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,9 +48,6 @@ pub struct Mold {
   /// path to the moldfile
   file: PathBuf,
 
-  /// path to the recipe scripts
-  dir: PathBuf,
-
   /// (derived) root directory that the file sits in
   root_dir: PathBuf,
 
@@ -88,13 +85,13 @@ impl Mold {
       ));
     }
 
-    let dir = path.with_file_name(&data.recipe_dir);
-    let root_dir = dir.parent().unwrap_or(&Path::new("/")).to_path_buf();
-    let clone_dir = dir.join(".clones");
-    let script_dir = dir.join(".scripts");
+    let root_dir = path.parent().unwrap_or(&Path::new("/")).to_path_buf();
+    let mold_dir = root_dir.join(".mold");
+    let clone_dir = mold_dir.join("clones");
+    let script_dir = mold_dir.join("scripts");
 
-    if !dir.is_dir() {
-      fs::create_dir(&dir)?;
+    if !mold_dir.is_dir() {
+      fs::create_dir(&mold_dir)?;
     }
     if !clone_dir.is_dir() {
       fs::create_dir(&clone_dir)?;
@@ -105,7 +102,6 @@ impl Mold {
 
     Ok(Mold {
       file: fs::canonicalize(path)?,
-      dir: fs::canonicalize(dir)?,
       root_dir: fs::canonicalize(root_dir)?,
       clone_dir: fs::canonicalize(clone_dir)?,
       script_dir: fs::canonicalize(script_dir)?,
@@ -295,7 +291,6 @@ impl Mold {
 
     vars.insert("MOLD_ROOT", self.root_dir.to_string_lossy());
     vars.insert("MOLD_FILE", self.file.to_string_lossy());
-    vars.insert("MOLD_DIR", self.dir.to_string_lossy());
     vars.insert("MOLD_CLONE_DIR", self.clone_dir.to_string_lossy());
     vars.insert("MOLD_SCRIPT_DIR", self.script_dir.to_string_lossy());
 


### PR DESCRIPTION
This replaces the `mold/` directory that was fairly standard in most projects. It was useful when scripts used to generally reside in there because of mold's default search behavior, but now that the search behavior is gone, there's no reason to formally keep it around. Clones and scripts are now placed directly into a `.mold` directory in the same location as the moldfile.

Close #62 