### PR TITLE
Implement a (hopefully) more cross-platform command syntax

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ semver = "0.9"
 serde = "1.0"
 serde_derive = "1.0"
 serde_yaml = "0.8"
+shell-words = "0.1.0"
 structopt = "0.3"
 which = "3.1"
 

--- a/mold.yaml
+++ b/mold.yaml
@@ -8,4 +8,5 @@ includes:
 recipes:
   staticbuild:
     help: "Build a static MUSL binary using Docker"
-    command: "sh $MOLD_ROOT/mold/staticbuild.sh"
+    command: "sh $MOLD_SCRIPT"
+    script: "sh $MOLD_ROOT/mold/staticbuild.sh"  # god this sucks.

--- a/mold.yaml
+++ b/mold.yaml
@@ -8,4 +8,4 @@ includes:
 recipes:
   staticbuild:
     help: "Build a static MUSL binary using Docker"
-    shell: "sh $MOLD_ROOT/mold/staticbuild.sh"
+    command: "sh $MOLD_ROOT/mold/staticbuild.sh"

--- a/src/file.rs
+++ b/src/file.rs
@@ -12,7 +12,7 @@ pub type IncludeVec = Vec<Include>;
 pub type TargetSet = IndexSet<String>;
 pub type VarMap = IndexMap<String, String>; // TODO maybe down the line this should allow nulls to `unset` a variable
 pub type EnvMap = IndexMap<String, VarMap>;
-pub type ShellMap = IndexMap<String, String>;
+pub type CommandMap = IndexMap<String, String>;
 
 // maps sorted alphabetically
 pub type RecipeMap = BTreeMap<String, Recipe>;
@@ -78,9 +78,9 @@ pub struct Include {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum Shell {
+pub enum Command {
   Shell(String),
-  Map(ShellMap),
+  Map(CommandMap),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -117,7 +117,7 @@ pub struct Recipe {
   ///
   /// eg: "bash $MOLD_ROOT/foo.sh"
   /// eg: "bash $MOLD_SCRIPT"
-  pub shell: Shell,
+  pub command: Command,
 
   /// The script contents as a multiline string
   ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,12 +6,12 @@ pub mod util;
 use colored::*;
 use failure::Error;
 use file::Command;
-use file::DEFAULT_FILES;
 use file::Moldfile;
 use file::Recipe;
 use file::Remote;
 use file::TargetSet;
 use file::VarMap;
+use file::DEFAULT_FILES;
 use indexmap::IndexMap;
 use semver::Version;
 use semver::VersionReq;
@@ -655,9 +655,7 @@ impl Recipe {
 
 impl Task {
   /// Execute a recipe
-  pub fn execute(
-    self,
-  ) -> Result<(), Error> {
+  pub fn execute(self) -> Result<(), Error> {
     if self.args.is_empty() {
       return Err(failure::err_msg("empty command cannot be executed"));
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,13 +5,13 @@ pub mod util;
 
 use colored::*;
 use failure::Error;
+use file::Command;
+use file::DEFAULT_FILES;
 use file::Moldfile;
 use file::Recipe;
 use file::Remote;
-use file::Shell;
 use file::TargetSet;
 use file::VarMap;
-use file::DEFAULT_FILES;
 use indexmap::IndexMap;
 use semver::Version;
 use semver::VersionReq;
@@ -612,9 +612,9 @@ impl ToString for Remote {
 impl Recipe {
   /// Figure out which command to run for our shell
   fn shell(&self, envs: &[String]) -> Result<String, Error> {
-    match &self.shell {
-      Shell::Shell(cmd) => return Ok(cmd.into()),
-      Shell::Map(map) => {
+    match &self.command {
+      Command::Shell(cmd) => return Ok(cmd.into()),
+      Command::Map(map) => {
         for (test, cmd) in map {
           match expr::compile(&test) {
             Ok(ex) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,7 +96,10 @@ fn run(args: Args) -> Result<(), Error> {
   let targets = mold.find_all_dependencies(&requested_targets)?;
 
   for target_name in &targets {
+    let recipe = mold.find_recipe(target_name)?;
     let args = mold.build_args(target_name)?;
+    let vars = mold.build_vars(target_name)?;
+    let args = mold.sub_vars(args, &vars)?;
     println!(
       "{} {} {} {}",
       "mold".white(),
@@ -104,7 +107,7 @@ fn run(args: Args) -> Result<(), Error> {
       "$".green(),
       args.join(" ")
     );
-    mold.execute(target_name)?;
+    mold.execute(args, vars, recipe.work_dir())?;
   }
 
   Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,21 +93,20 @@ fn run(args: Args) -> Result<(), Error> {
     .iter()
     .map(std::string::ToString::to_string)
     .collect();
-  let targets = mold.find_all_dependencies(&requested_targets)?;
+  let all_targets = mold.find_all_dependencies(&requested_targets)?;
 
-  for target_name in &targets {
-    let recipe = mold.find_recipe(target_name)?;
-    let vars = mold.build_vars(recipe)?;
-    let args = mold.sub_vars(mold.build_args(recipe)?, &vars)?;
+  for target_name in &all_targets {
+    let task = mold.build_task(target_name)?;
 
     println!(
       "{} {} {} {}",
       "mold".white(),
       target_name.cyan(),
       "$".green(),
-      args.join(" ")
+      shell_words::join(task.args()),
     );
-    mold.execute(args, vars, recipe.work_dir())?;
+
+    task.execute()?;
   }
 
   Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,9 +97,9 @@ fn run(args: Args) -> Result<(), Error> {
 
   for target_name in &targets {
     let recipe = mold.find_recipe(target_name)?;
-    let args = mold.build_args(target_name)?;
-    let vars = mold.build_vars(target_name)?;
-    let args = mold.sub_vars(args, &vars)?;
+    let vars = mold.build_vars(recipe)?;
+    let args = mold.sub_vars(mold.build_args(recipe)?, &vars)?;
+
     println!(
       "{} {} {} {}",
       "mold".white(),


### PR DESCRIPTION
See #72 

I think the `$SHELL -c ...` syntax just straight up doesn't work on Windows, but the standard `Command` interface of providing `argv` *does* work. But writing `["ls", "-l"]` in YAML is a pain in the ass. So I'm using [shell-words](https://docs.rs/shell-words/0.1.0/shell_words/) to lex the given string as a POSIX shell command, then doing some minimal variable substitution so not everything needs to be shoved into the `script` section.