### PR TITLE
Replace `git2` library with external Git calls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ env_logger = "0.6"
 exitcode = "1.1"
 exitfailure = "0.5"
 failure = "0.1"
-git2 = "0.8"
 indexmap = {version = "1.0", features = ["serde-1"]}
 log = "0.4"
 semver = "0.9"

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -1,7 +1,5 @@
 use colored::*;
 use failure::Error;
-use git2::Cred;
-use git2::CredentialType;
 use std::io;
 use std::io::Write;
 use std::path::Path;
@@ -68,23 +66,6 @@ impl<'a> State<'a> {
       self.print_progress();
     }
     Ok(())
-  }
-}
-
-pub fn git_credentials_callback(
-  _user: &str,
-  _user_from_url: Option<&str>,
-  _cred: CredentialType,
-) -> Result<Cred, git2::Error> {
-  if let Some(home_dir) = dirs::home_dir() {
-    let pub_key = home_dir.join(".ssh/id_rsa.pub");
-    let priv_key = home_dir.join(".ssh/id_rsa");
-    let credentials = Cred::ssh_key("git", Some(&pub_key), &priv_key, None)
-      .expect("Could not create credentials object");
-
-    Ok(credentials)
-  } else {
-    Err(git2::Error::from_str("Couldn't locate home directory"))
   }
 }
 


### PR DESCRIPTION
Eh. Dunno. Seems a little weird now. I think the `git2` bindings were confusing as hell, but this just has so much boring boilerplate going around... not sure of the `State` design either.

`rev-parse` doesn't use `State` because there's probably a near-instant response, as opposed to `checkout` and `fetch` which can incur some serious wall time. But that means that they use two different pieces of code - calling `rev-parse` vs calling `fetch` / `checkout`. Dunno.