### PR TITLE
Improve variable expansion in command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_yaml = "0.8"
 shell-words = "0.1.0"
+shellexpand = "1.1.1"
 structopt = "0.3"
 which = "3.1"
 

--- a/mold.yaml
+++ b/mold.yaml
@@ -8,5 +8,4 @@ includes:
 recipes:
   staticbuild:
     help: "Build a static MUSL binary using Docker"
-    command: "sh $MOLD_SCRIPT"
-    script: "sh $MOLD_ROOT/mold/staticbuild.sh"  # god this sucks.
+    command: "sh $MOLD_ROOT/mold/staticbuild.sh"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -270,7 +270,7 @@ impl Mold {
         .get(name)
         .map(std::string::ToString::to_string)
         .or_else(|| std::env::var(name).ok())
-        .or(Some("".into()))
+        .or_else(|| Some("".into()))
     });
     Ok(shell_words::split(&expanded)?)
   }

--- a/test.yaml
+++ b/test.yaml
@@ -15,30 +15,26 @@ environments:
 recipes:
   foo:
     help: "Hello world inline shell"
-    shell:
+    command:
       unix: "echo 'this is running in a unix world'"
       windows: "echo 'this is running in a windows world'"
 
   python:
     help: "Hello world external Python"
-    shell: "python $MOLD_ROOT/mold/python.py"
-    variables:
-      NAME: "Recipient of greeting."
+    command: "python $MOLD_ROOT/mold/python.py"
 
   python-script:
     help: "Hello world inline Python"
-    shell: "python $MOLD_SCRIPT"
+    command: "python $MOLD_SCRIPT"
     script: |
       print("Hello, world!")
 
   shell:
     help: "Hello world external shell"
-    shell: "sh $MOLD_ROOT/mold/shell.sh"
-    variables:
-      NAME: "Recipient of greeting."
+    command: "sh $MOLD_ROOT/mold/shell.sh"
 
   shell-script:
     help: "Hello world inline shell"
-    shell: "sh $MOLD_SCRIPT"
+    command: "sh $MOLD_SCRIPT"
     script: |
       echo "Hello, world!"


### PR DESCRIPTION
Uses the [shellexpand](https://netvl.github.io/shellexpand/shellexpand/index.html) crate.

I couldn't get the claimed `${foo:-default}` to work, but whatever. I thought it might be because I default to always finding an empty string, but even without that line, it still doesn't work.

Close #81 