### PR TITLE
Add "default value" statements

### DIFF
--- a/src/lang.rs
+++ b/src/lang.rs
@@ -278,7 +278,6 @@ pub fn compile_recipe(
   let mut dir = None;
   let mut commands = vec![];
   let mut requires = super::TargetSet::new();
-  let mut vars = super::VarMap::new();
 
   let body = flatten(body, &mold.envs)?;
 
@@ -292,16 +291,6 @@ pub fn compile_recipe(
         dir = Some(s);
       }
 
-      Var(name, value) => {
-        vars.insert(name, value);
-      }
-
-      Default(name, value) => {
-        if !vars.contains_key(&name) && std::env::var(&name).is_err() {
-          vars.insert(name, value);
-        }
-      }
-
       Run(cmd) => {
         commands.push(cmd);
       }
@@ -310,7 +299,7 @@ pub fn compile_recipe(
         requires.insert(recipe);
       }
 
-      If(_, _) | Version(_) | Import(_, _) | Recipe(_, _) => {
+      If(_, _) | Version(_) | Import(_, _) | Recipe(_, _) | Var(_, _) | Default(_, _) => {
         unreachable!();
       }
     }
@@ -319,7 +308,6 @@ pub fn compile_recipe(
   Ok(super::Recipe {
     help,
     commands,
-    vars,
     dir,
     requires,
   })

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -214,6 +214,7 @@ pub fn compile(code: &str, envs: &super::EnvSet) -> Result<super::Moldfile, Erro
   let mut includes = super::IncludeVec::new();
   let mut recipes = super::RecipeMap::new();
   let mut vars = super::VarMap::new();
+  let mut defaults = super::VarMap::new();
 
   for stmt in statements {
     match stmt {
@@ -237,8 +238,8 @@ pub fn compile(code: &str, envs: &super::EnvSet) -> Result<super::Moldfile, Erro
       }
 
       Default(name, value) => {
-        if std::env::var(&name).is_err() {
-          vars.insert(name, value);
+        if !defaults.contains_key(&name) {
+          defaults.insert(name, value);
         }
       }
 
@@ -263,6 +264,7 @@ pub fn compile(code: &str, envs: &super::EnvSet) -> Result<super::Moldfile, Erro
     includes,
     recipes,
     vars,
+    defaults,
     dir,
   })
 }
@@ -276,6 +278,7 @@ pub fn compile_recipe(body: Vec<Statement>, envs: &super::EnvSet) -> Result<supe
   let mut commands = vec![];
   let mut requires = super::TargetSet::new();
   let mut vars = super::VarMap::new();
+  let mut defaults = super::VarMap::new();
 
   let body = flatten(body, envs)?;
 
@@ -294,8 +297,8 @@ pub fn compile_recipe(body: Vec<Statement>, envs: &super::EnvSet) -> Result<supe
       }
 
       Default(name, value) => {
-        if std::env::var(&name).is_err() {
-          vars.insert(name, value);
+        if !defaults.contains_key(&name) {
+          defaults.insert(name, value);
         }
       }
 
@@ -319,6 +322,7 @@ pub fn compile_recipe(body: Vec<Statement>, envs: &super::EnvSet) -> Result<supe
     vars,
     dir,
     requires,
+    defaults,
   })
 }
 

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -237,7 +237,10 @@ pub fn compile(code: &str, mold: &mut super::Mold) -> Result<super::Moldfile, Er
       }
 
       Default(name, value) => {
-        if !vars.contains_key(&name) && std::env::var(&name).is_err() {
+        if !vars.contains_key(&name)
+          && !mold.vars.contains_key(&name)
+          && std::env::var(&name).is_err()
+        {
           vars.insert(name, value);
         }
       }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,7 +204,7 @@ impl Mold {
 
     // if this file has a `dir` stmt, it overrides any other dir that was set
     if let Some(rel_path) = data.dir {
-      self.work_dir = Some(rel_path.to_string());
+      self.work_dir = Some(rel_path);
     }
 
     Ok(())
@@ -303,7 +303,7 @@ impl Mold {
     let work_dir = recipe
       .dir
       .clone()
-      .or(self.work_dir.clone())
+      .or_else(|| self.work_dir.clone())
       .map(|raw_path| {
         self
           .root_dir

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,9 +78,6 @@ pub struct Recipe {
   /// The command to execute
   pub commands: Vec<String>,
 
-  /// A list of environment variables
-  pub vars: VarMap,
-
   /// A list of prerequisite recipes
   pub requires: TargetSet,
 }
@@ -289,10 +286,7 @@ impl Mold {
   fn build_task(&self, name: &str) -> Result<Task, Error> {
     let recipe = self.recipe(name)?;
 
-    // variables prioritize the _recipe_ values, so it extends the _file_ values. this is because
-    // later assignments should override the previous value, and recipes are handled "after" files.
     let mut vars = self.vars.clone();
-    vars.extend(recipe.vars.clone());
 
     // insert var for where this recipe's mold file lives
     if let Some(source) = self.sources.get(name) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ pub struct Mold {
   /// Working directory
   ///
   /// This is overridden by a recipe's `dir`
-  pub work_dir: Option<PathBuf>,
+  pub work_dir: Option<String>,
 }
 
 /// An external module included for reuse
@@ -184,8 +184,7 @@ impl Mold {
 
       self.recipes.entry(new_key.clone()).or_insert(new_recipe);
 
-      // keep track of where this recipe came from so it can use things from
-      // its repo
+      // keep track of where this recipe came from so it can use things from its repo
       self.sources.entry(new_key).or_insert(root_dir.clone());
     }
 
@@ -201,15 +200,11 @@ impl Mold {
       self.open(&filepath, &include.prefix)?;
     }
 
-    for (name, val) in data.vars {
-      let expanded_val = self.expand(&val, &self.vars);
-      self.vars.insert(name, expanded_val.into());
-    }
+    self.vars.extend(data.vars);
 
     // if this file has a `dir` stmt, it overrides any other dir that was set
     if let Some(rel_path) = data.dir {
-      let expanded_path = self.expand(&rel_path, &self.vars);
-      self.work_dir = Some(self.root_dir.join(expanded_path.to_string()));
+      self.work_dir = Some(rel_path.to_string());
     }
 
     Ok(())
@@ -286,9 +281,13 @@ impl Mold {
   fn build_task(&self, name: &str) -> Result<Task, Error> {
     let recipe = self.recipe(name)?;
 
-    let mut vars = self.vars.clone();
+    // expand all variables
+    let mut vars = VarMap::new();
+    for (name, value) in &self.vars {
+      vars.insert(name.clone(), self.expand(value, &vars).into());
+    }
 
-    // insert var for where this recipe's mold file lives
+    // insert var for where this recipe's moldfile lives
     if let Some(source) = self.sources.get(name) {
       vars.insert("MOLD_SOURCE".into(), source.to_string_lossy().into());
     } else {
@@ -298,24 +297,28 @@ impl Mold {
       ));
     }
 
-    let mut commands = vec![];
+    // select the recipe's working dir if it's defined, otherwise select the Mold's working dir. in
+    // both cases, we want to expand the variables afterwards and join it with $MOLD_ROOT. if
+    // neither dir is defined, the command will default to the current working dir.
+    let work_dir = recipe
+      .dir
+      .clone()
+      .or(self.work_dir.clone())
+      .map(|raw_path| {
+        self
+          .root_dir
+          .join(self.expand(&raw_path, &vars).to_string())
+      });
 
+    // build the command strings to execute
+    let mut commands = vec![];
     for command_str in &recipe.commands {
       let args = self.build_args(command_str, &vars)?;
-
       if args.is_empty() {
         continue;
       }
-
       commands.push(args);
     }
-
-    let work_dir = if let Some(rel_path) = &recipe.dir {
-      let expanded_path = self.expand(&rel_path, &vars);
-      Some(self.root_dir.join(expanded_path.to_string()))
-    } else {
-      self.work_dir.clone()
-    };
 
     Ok(Task {
       name: name.into(),

--- a/src/mold.pest
+++ b/src/mold.pest
@@ -16,7 +16,7 @@ name = @{ (alpha | digit | special)+ }
 
 main = _{ SOI ~ main_body ~ EOI }
 main_body = _{ (version_stmt | import_stmt | recipe_stmt | dir_stmt | var_stmt | default_stmt | if_stmt)* }
-recipe_body = _{ (help_stmt | if_recipe_stmt | dir_stmt | require_stmt | var_stmt | default_stmt | run_stmt )* }
+recipe_body = _{ (help_stmt | if_recipe_stmt | dir_stmt | require_stmt | run_stmt )* }
 
 dir_stmt = { "dir" ~ string }
 help_stmt = { "help" ~ string }

--- a/src/mold.pest
+++ b/src/mold.pest
@@ -27,7 +27,7 @@ recipe_stmt = { "recipe" ~ name ~ "{" ~ recipe_body ~ "}" }
 require_stmt = { "require" ~ name }
 run_stmt = { ("run" | "$") ~ string }
 var_stmt = { "var" ~ name ~ "=" ~ string }
-default_stmt = { "default" ~ name ~ "=" ~ string }
+default_stmt = { "var" ~ name ~ ":=" ~ string }
 version_stmt = { "version" ~ string }
 
 // this is some weird stuff to avoid needing to use a precedence climber

--- a/src/mold.pest
+++ b/src/mold.pest
@@ -15,8 +15,8 @@ special = { "_" | "-" | "/" | ":" }
 name = @{ (alpha | digit | special)+ }
 
 main = _{ SOI ~ main_body ~ EOI }
-main_body = _{ (version_stmt | import_stmt | recipe_stmt | dir_stmt | var_stmt | if_stmt)* }
-recipe_body = _{ (help_stmt | if_recipe_stmt | dir_stmt | require_stmt | var_stmt | run_stmt )* }
+main_body = _{ (version_stmt | import_stmt | recipe_stmt | dir_stmt | var_stmt | default_stmt | if_stmt)* }
+recipe_body = _{ (help_stmt | if_recipe_stmt | dir_stmt | require_stmt | var_stmt | default_stmt | run_stmt )* }
 
 dir_stmt = { "dir" ~ string }
 help_stmt = { "help" ~ string }
@@ -27,6 +27,7 @@ recipe_stmt = { "recipe" ~ name ~ "{" ~ recipe_body ~ "}" }
 require_stmt = { "require" ~ name }
 run_stmt = { ("run" | "$") ~ string }
 var_stmt = { "var" ~ name ~ "=" ~ string }
+default_stmt = { "default" ~ name ~ "=" ~ string }
 version_stmt = { "version" ~ string }
 
 // this is some weird stuff to avoid needing to use a precedence climber


### PR DESCRIPTION
The implementation was a little trickier than I intended because the behavior was a little trickier than I expected. The current details for handling variable assignments are roughly as follows:

* A `Mold` is created as the main execution context with a variable map containing a few special Mold variables like `MOLD_ROOT` and `MOLD_DIR`
* A `Moldfile` is created from a source file and collects all of the top-level variable assignments into its own variable map
* Each `Recipe` in a `Moldfile` collects all of its internal variable assignments into its own variable map
* When the `Mold` _opens_ a `Moldfile`, such as the initial file or during an import, all of the `Moldfile`'s contents (recipes, variables, etc) are merged into the `Mold`, overriding any existing values.
* When a `Recipe` is executed, the recipe's contents (working dir, variables, etc) are merged into a copy of the the `Mold`'s contents, overriding any existing values.
* When variable expansion takes place, variables are looked up in the `Recipe`'s execution variable map and fall back to the OS environment.
* Variable assignments unconditionally override previous assignments, meaning the latest assignment takes priority.

So, in short, the variable priority is roughly: `Recipe` variables > `Moldfile` variables > environment variables. Because of this ordering, it's not possible for Mold to provide a default value for a variable that can be overridden by the environment; any default values will have to be handled in the script rather than in Mold.

The open issue #128 is intended to address this, and I was expecting that I could simply parse the default assignment and apply it if the variable map and environment turned up empty. Because of the multi-layered variable system (`Mold`, `Moldfile`, and `Recipe`), my initial assumptions don't work out well without breaking some boundaries: a `Moldfile` would need to inspect the variable map of the `Mold` that's opening it, and a `Recipe` would need to inspect the variable map of the `Moldfile` that defines it, etc. Unfortunately, I don't think that's feasible and would significantly impact the interfaces between those concepts.

The approach I've taken here is to add a _secondary_ variable map, `defaults`, for all three structures. This variable map takes the _opposite_ prioritization approach: the _first_ definition takes priority, rather than the _last_. That is:

```
var foo = "one"
var foo = "two"
```

`$foo` would evaluate to `"two"` here (last assignment takes priority), while:

```
default foo = "one"
default foo = "two"
```

`$foo` would evaluate to `"one"` here (first assignment takes priority).

Following the way that `Recipe`s are treated as happening "after" the `Moldfile`, allowing their variables override the file's, but respecting the inversion of priority for default variables, the file's defaults override the recipe's defaults. Default values are appended to the priority list _after_ environment variables, making the final priority list look something like this: `Recipe` variables > `Moldfile` variables > environment variables > `Moldfile` defaults > `Recipe` defaults.