### PR TITLE
Add user-facing error context messages

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use colored::*;
 use exitfailure::ExitFailure;
 use failure::Error;
 use mold::Mold;
@@ -79,7 +80,16 @@ fn run(args: Args) -> Result<(), Error> {
             format!("import \"{}\"\n", import)
         };
 
-        let mut file = std::fs::OpenOptions::new().append(true).open(filepath)?;
+        let mut file = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&filepath)
+            .map_err(|err| {
+                failure::format_err!(
+                    "Couldn't open file {} for appending: {}",
+                    filepath.display().to_string().red(),
+                    err
+                )
+            })?;
         file.write_all(line.as_bytes())?;
         return Ok(());
     }

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -93,8 +93,7 @@ fn checkout(path: &Path, ref_: &str) -> Result<(), Error> {
             let branch_name = format!("origin/{}", ref_);
             let object = repo
                 .revparse_single(&tag_name)
-                .or_else(|_| repo.revparse_single(&branch_name))
-                .map_err(|_| failure::format_err!("Unable to locate ref '{}'", ref_.red()))?;
+                .or_else(|_| repo.revparse_single(&branch_name))?;
             repo.set_head_detached(object.id())?;
 
             // force checkout


### PR DESCRIPTION
It adds a lot of code, but it really helps to add context to the user
for why the program failed. A lot of the context messages contain extra
information about the particular action that was happening when an error
occurred.

Close #133 